### PR TITLE
add build tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14-alpine
+WORKDIR /app/meedu-backend
+
+COPY package*.json ./
+RUN npm config set registry https://registry.npm.taobao.org \
+    && yarn install \
+    && npm install -g hey-cli
+
+COPY . .
+
+CMD ["hey", "build"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+commit_id=`git log -1 --pretty=format:"%h"`
+tag=meedu-backend:$commit_id
+dist=`pwd`/dist
+echo "will build $tag to $dist"
+
+rm -rf $dist
+docker build ./ -t $tag
+
+mkdir -p $dist
+docker run --rm -v $dist:/app/meedu-backend/dist:rw $tag
+
+echo "build success @ $dist"


### PR DESCRIPTION
```
./build.sh 
will build meedu-backend:f9c074d to /path/backend/dist
Sending build context to Docker daemon  4.285MB
Step 1/6 : FROM node:14-alpine
 ---> 38f7251093f0
Step 2/6 : WORKDIR /app/meedu-backend
 ---> Using cache
 ---> 1518e9f03af9
Step 3/6 : COPY package*.json ./
 ---> Using cache
 ---> 405dcb51ff78
Step 4/6 : RUN npm config set registry https://registry.npm.taobao.org     && yarn install     && npm install -g hey-cli
 ---> Using cache
 ---> 84bd470baf64
Step 5/6 : COPY . .
 ---> 51743f527bb5
Step 6/6 : CMD ["hey", "build"]
 ---> Running in 83431a390185
Removing intermediate container 83431a390185
 ---> 9f4273a08992
Successfully built 9f4273a08992
Successfully tagged meedu-backend:f9c074d
 HEY CLI v2.7.1 
[HEY] Start remove dist folder. 
[HEY] Build cleaned, removed dist folder. 
[HEY] Start build project... 

[HEY] Compiled successfully
[HEY] Start copying. 
[HEY] Copy complete. 
[HEY] Build successfully. 
[HEY] Use webpack-bundle-analyzer: hey report
[HEY] For more information, see https://github.com/heyui/hey-cli
build success /path/backend/dist
```

https://registry.npm.taobao.org  可以讨论要不要设置
